### PR TITLE
CDEV-434 Lang Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ The shortcode takes in 4 parameters:
 	* Accepted parameter value: `development`
 	* You can use this flag to serve all content from the sandbox environment.
 	* Note that this parameter ***should not*** be utilized for production purposes.
+* `lang` - *optional*
+	* the language code that you want the widget to be translated to. This should correspond with the language code you set in the appearance section of the platform

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ The shortcode takes in 4 parameters:
 	* You can use this flag to serve all content from the sandbox environment.
 	* Note that this parameter ***should not*** be utilized for production purposes.
 * `lang` - *optional*
-	* the language code that you want the widget to be translated to. This should correspond with the language code you set in the appearance section of the platform
+	* The language code that you want the widget to be translated to. The naming convention for the language's name is based on the ISO-639 language code (e.g. pt for Portuguese) followed by the ISO-3166 country code (e.g. _PT for Portugal or _BR for Brazil), and corresponds with the language codes set in the "appearance" section of the Olapic platform.

--- a/olapic-widget/olapic-widget.php
+++ b/olapic-widget/olapic-widget.php
@@ -25,13 +25,13 @@ function olapic_function($atts)
 
     $data_instance = "data-instance=\"{$arguments['instance-id']}\"";
     $data_apikey = "data-apikey=\"{$arguments['apikey']}\"";
+    //since data-tags, data-lang and data-mode aren't required, checks if its empty before giving it a value
     $data_tags = !empty($arguments['tags']) ? "data-tags=\"{$arguments['tags']}\"" : '';
     $data_mode = !empty($arguments['mode']) ? "data-mode=\"{$arguments['mode']}\"" : '';
     $data_lang = !empty($arguments['lang']) ? "data-lang=\"{$arguments['lang']}\"" : '';
-    //since data-tags, data-lang and data-mode aren't required, checks if its empty before giving it a value
+
 
     $olapic_output = "<div id=\"olapic_specific_widget\"></div><script type=\"text/javascript\" src=\"//photorankstatics-a.akamaihd.net/81b03e40475846d5883661ff57b34ece/static/frontend/latest/build.min.js\"  data-olapic=\"olapic_specific_widget\" {$data_instance} {$data_apikey} {$data_tags} {$data_mode} {$data_lang} async=\"async\"></script>" ;
-    //changed from using concatenation. Concatenation using the dot operator will concatenate each one individually. Using curly braces will place the variables in once - better practice when using multiple concatenations
-
+   
     return $olapic_output;
 }

--- a/olapic-widget/olapic-widget.php
+++ b/olapic-widget/olapic-widget.php
@@ -20,6 +20,7 @@ function olapic_function($atts)
         'apikey' => '',
         'tags' => '',
         'mode' => '',
+        'lang' => '',
     ), $atts);
 
     $data_instance = "data-instance=\"{$arguments['instance-id']}\"";
@@ -29,7 +30,7 @@ function olapic_function($atts)
     $data_lang = !empty($arguments['lang']) ? "data-lang=\"{$arguments['lang']}\"" : '';
     //since data-tags, data-lang and data-mode aren't required, checks if its empty before giving it a value
 
-    $olapic_output = "<div id=\"olapic_specific_widget\"></div><script type=\"text/javascript\" src=\"//photorankstatics-a.akamaihd.net/81b03e40475846d5883661ff57b34ece/static/frontend/latest/build.min.js\"  data-olapic=\"olapic_specific_widget\" {$data_instance} {$data_apikey} {$data_tags} {$data_mode} {$data_lang} async=\"async\"></script>";
+    $olapic_output = "<div id=\"olapic_specific_widget\"></div><script type=\"text/javascript\" src=\"//photorankstatics-a.akamaihd.net/81b03e40475846d5883661ff57b34ece/static/frontend/latest/build.min.js\"  data-olapic=\"olapic_specific_widget\" {$data_instance} {$data_apikey} {$data_tags} {$data_mode} {$data_lang} async=\"async\"></script>" ;
     //changed from using concatenation. Concatenation using the dot operator will concatenate each one individually. Using curly braces will place the variables in once - better practice when using multiple concatenations
 
     return $olapic_output;

--- a/olapic-widget/olapic-widget.php
+++ b/olapic-widget/olapic-widget.php
@@ -26,9 +26,10 @@ function olapic_function($atts)
     $data_apikey = "data-apikey=\"{$arguments['apikey']}\"";
     $data_tags = !empty($arguments['tags']) ? "data-tags=\"{$arguments['tags']}\"" : '';
     $data_mode = !empty($arguments['mode']) ? "data-mode=\"{$arguments['mode']}\"" : '';
-    //since data-tags and data-mode aren't required, checks if its empty before giving it a value
+    $data_lang = !empty($arguments['lang']) ? "data-lang=\"{$arguments['lang']}\"" : '';
+    //since data-tags, data-lang and data-mode aren't required, checks if its empty before giving it a value
 
-    $olapic_output = "<div id=\"olapic_specific_widget\"></div><script type=\"text/javascript\" src=\"//photorankstatics-a.akamaihd.net/81b03e40475846d5883661ff57b34ece/static/frontend/latest/build.min.js\"  data-olapic=\"olapic_specific_widget\" {$data_instance} {$data_apikey} {$data_tags} {$data_mode} async=\"async\"></script>";
+    $olapic_output = "<div id=\"olapic_specific_widget\"></div><script type=\"text/javascript\" src=\"//photorankstatics-a.akamaihd.net/81b03e40475846d5883661ff57b34ece/static/frontend/latest/build.min.js\"  data-olapic=\"olapic_specific_widget\" {$data_instance} {$data_apikey} {$data_tags} {$data_mode} {$data_lang} async=\"async\"></script>";
     //changed from using concatenation. Concatenation using the dot operator will concatenate each one individually. Using curly braces will place the variables in once - better practice when using multiple concatenations
 
     return $olapic_output;


### PR DESCRIPTION
What does this pull request do?
---------------------------------
Updates the plugin to accept the "lang" parameter in the shortcode, which maps to the data-language parameter in the olapic widget code. 

How to test this
----------------
In order to test this you'll need to be able to have access to a wordpress instance. I downloaded mamp, and downloaded wordpress, and placed the wordpress directory into the mamp/htdocs folder and logged in. 

Next you'll need to install the plugin itself - to do this you can simply place the olapic-widget.php file into the mamp/htdocs/wordpress/wp-content/plugins directory. 

Finally, you need to test it. To do this you can place the following code into a test word press page, and preview it.

```
[olapic instance-id="816c53094bf966c71780c041ba7868bf" apikey="cfa3e701a4b8d562e4b6f085b10d0e31467f6e3d4aafbd170314335c158d214c" tags="og-laura" mode="development" lang="de_DE" ]
```

You should be able to see the translated widget


Related Tickets
----------------
[CDEV-434](https://photorank.atlassian.net/browse/CDEV-434)